### PR TITLE
Replace JSON with TOML using tomland

### DIFF
--- a/Hibet.cabal
+++ b/Hibet.cabal
@@ -15,7 +15,7 @@ build-type:          Simple
 extra-doc-files:     README.md
                    , CHANGELOG.md
 data-files:          dicts/*.txt
-                   , stuff/titles.json
+                   , stuff/titles.toml
                    , stuff/tibetan-syllables
 tested-with:         GHC == 8.6.4
 
@@ -46,7 +46,6 @@ library
                        -Wpartial-fields
 
   build-depends:       base ^>= 4.12.0.0
-                     , aeson
                      , ansi-terminal
                      , bifunctors
                      , bytestring
@@ -65,6 +64,7 @@ library
                      , path-io >= 1.4.0
                      , radixtree
                      , text
+                     , tomland >= 1.1.0.1
                      , unordered-containers
 
   default-language:    Haskell2010

--- a/src/Labels.hs
+++ b/src/Labels.hs
@@ -1,44 +1,30 @@
+{-# OPTIONS -Wno-unused-top-binds #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE OverloadedStrings    #-}
+
 module Labels
        ( LabelFull(..)
        , labels
        ) where
 
-import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), decode, object, withObject, (.:), (.=))
 import Data.List (sortOn)
 import Data.Text (Text)
+import Toml (TomlCodec, (.=))
 
 import Paths_Hibet (getDataFileName)
 
-import qualified Data.ByteString.Lazy.Char8 as BLC
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Text.IO as TIO
+import qualified Toml
 
 
 labels :: IO [LabelFull]
 labels = do
-    file <- getDataFileName "stuff/titles.json"
-    meta <- BLC.readFile file
-    case decode meta :: Maybe Labels of
-        Nothing               -> error "Not decoded"
-        Just (Labels decoded) -> pure $ sortOn lfId decoded
+    file <- getDataFileName "stuff/titles.toml"
+    meta <- TIO.readFile file
+    case Toml.decode labelsCodec meta of
+        Left err               -> error $ show err
+        Right (Labels decoded) -> pure $ sortOn lfId decoded
 
-data Label = Label
-    { labelId    :: Int
-    , labelLabel :: Text
-    , labelMeta  :: Text
-    } deriving (Eq, Show, Ord)
-
-instance ToJSON Label where
-    toJSON Label{..} = object
-        [ "id"     .= labelId
-        , "label"  .= labelLabel
-        , "about"  .= labelMeta
-        ]
-
-instance FromJSON Label where
-    parseJSON = withObject "label" $ \v -> Label
-        <$> v .: "id"
-        <*> v .: "label"
-        <*> v .: "about"
 
 data LabelFull = LabelFull
     { lfPath  :: Text
@@ -47,12 +33,19 @@ data LabelFull = LabelFull
     , lfMeta  :: Text
     } deriving (Eq, Show, Ord)
 
-newtype Labels = Labels [LabelFull]
-    deriving (Eq, Show)
 
-instance FromJSON Labels where
-    parseJSON v = Labels . map toLabelFull . HM.toList <$> parseJSON v
-      where
-        toLabelFull (path, Label number label about) = LabelFull path number label about
+data Labels = Labels
+    { labelTitles :: [LabelFull]
+    } deriving (Eq, Show)
+
+labelFullCodec :: TomlCodec LabelFull
+labelFullCodec = LabelFull
+    <$> Toml.text "path"  .= lfPath
+    <*> Toml.int  "id"    .= lfId
+    <*> Toml.text "label" .= lfLabel
+    <*> Toml.text "about" .= lfMeta
 
 
+labelsCodec :: TomlCodec Labels
+labelsCodec = Labels
+    <$> Toml.list labelFullCodec "titles" .= labelTitles

--- a/src/Labels.hs
+++ b/src/Labels.hs
@@ -1,7 +1,3 @@
-{-# OPTIONS -Wno-unused-top-binds #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE OverloadedStrings    #-}
-
 module Labels
        ( LabelFull(..)
        , labels
@@ -13,14 +9,15 @@ import Toml (TomlCodec, (.=))
 
 import Paths_Hibet (getDataFileName)
 
-import qualified Data.Text.IO as TIO
+import qualified Data.ByteString as BS
+import qualified Data.Text.Encoding as TE
 import qualified Toml
 
 
 labels :: IO [LabelFull]
 labels = do
     file <- getDataFileName "stuff/titles.toml"
-    meta <- TIO.readFile file
+    meta <- TE.decodeUtf8 <$> BS.readFile file
     case Toml.decode labelsCodec meta of
         Left err               -> error $ show err
         Right (Labels decoded) -> pure $ sortOn lfId decoded

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,9 @@ resolver: lts-13.19
 extra-deps:
     - path-io-1.4.0
     - radixtree-0.4.0.0
+    - tomland-1.1.0.1
+    - megaparsec-7.0.5
+    - parser-combinators-1.2.0
     - parsers-megaparsec-0.1.0.1
 
 ghc-options:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,6 +19,27 @@ packages:
   original:
     hackage: radixtree-0.4.0.0
 - completed:
+    hackage: tomland-1.1.0.1@sha256:dcf629b1a39006276823b3bbf48658816e0812abeb55a8e84f7b9d8301166898,6589
+    pantry-tree:
+      size: 3622
+      sha256: dcfe03cbfa5df93a92a68daaa589b9a222dfd1ec3a9b8d6fda890c77c95c0be7
+  original:
+    hackage: tomland-1.1.0.1
+- completed:
+    hackage: megaparsec-7.0.5@sha256:45e1f1348fab2783646fdb4d9e6097568981a740951c7356d36d794e2baba305,3902
+    pantry-tree:
+      size: 1428
+      sha256: 1f8baf6e07326f8c8a2dd31de6b2860427f158b0892c52ba5fe9ffeb6cd3bf7f
+  original:
+    hackage: megaparsec-7.0.5
+- completed:
+    hackage: parser-combinators-1.2.0@sha256:784ab858e0a814d2aa36785e3c359a393be7ef7be9a37428a59908331249eb80,1845
+    pantry-tree:
+      size: 725
+      sha256: 2bc4acaba61498d2f8d1eefcaeb557e8612cb2058918203fddc7f1595966b11b
+  original:
+    hackage: parser-combinators-1.2.0
+- completed:
     hackage: parsers-megaparsec-0.1.0.1@sha256:2ebe722e6468bdfa1c236e2106815b0132e152eada60607f1f5f607a5f759037,1670
     pantry-tree:
       size: 238

--- a/stuff/titles.toml
+++ b/stuff/titles.toml
@@ -1,0 +1,373 @@
+[[titles]]
+    path = "TsepakRigdzin"
+    id = 1
+    label = "Tsepak Rigdzin"
+    highlight = "\\[([^\\]]*)\\]"
+    about = "Tibetan-English Dictionary of Buddhist Terms|Revised and Enlarged Edition|Tsepak Rigdzin|Library of Tibetan Works and Archives|ISBN: 81-85102-88-0"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Gaeng,Wetzel"
+    id = 2
+    label = "Gäng / Wetzel"
+    about = "Buddhist Terms|Multilingual Version|Edited by Peter Gäng and Sylvia Wetzel|Buddhist Academy Berlin Brandenburg|June 2004|Source:  http://www.buddhistische-akademie-bb.de/pdf/BuddhistTerms.pdf"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Drungtso"
+    id = 3
+    label = "Drungtso - Medical; Astro Terms"
+    highlight = "(&lt;[^&]*&gt;)"
+    about = "Tibetan-English Dictionary of Tibetan Medicine and Astrology|First Edition, Drungtso Publications 1999| Dr. Tsering Thakchoe Drungtso | Mrs. Tsering Dolma Drungtso"
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "Illuminator_x"
+    id = 4
+    label = "Illuminator"
+    highlight = "(&lt;[^ ]*&gt;)"
+    about = "The Illuminator Tibetan-English Encyclopaedic Dictionary|Version 5.23, January 2014|Tony Duff 2000-2014, All rights reserved|If you use this dictionary, please buy it at: www.pktc.org/pktc"
+    abbreviations = "Illuminator"
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "Hopkins2015"
+    id = 5
+    label = "Hopkins 2015"
+    about = "The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+    listCredits = "true"
+
+
+[[titles]]
+    path = "CommonTerms-Lin"
+    id = 6
+    label = "Chung-An Lin"
+    about = "Common Chinese-Tibetan-Sanskrit-English Buddhist Terminology|Compiled by Chung-An Lin, assisted by Hou-Wha Wang|2008|www.insights.org.tw"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "RangjungYeshe"
+    id = 7
+    label = "Rangjung Yeshe"
+    about = "Rangjung Yeshe Dictionary|Rangjung Yeshe Tibetan-English Dharma Dictionary 3.0 by Erik Pema Kunsang (2003)|online version: http://rywiki.tsadra.org"
+    abbreviations = "RangjungYeshe"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Berzin"
+    id = 8
+    label = "Berzin"
+    mergeLines = true
+    about = "Dr. Alexander Berzin\"s English-Tibetan-Sanskrit Glossary|These entries are from the glossary of www.berzinarchives.com"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Berzin-Def"
+    id = 9
+    label = "Berzin Definitions"
+    about = "Source: Alexander Berzin\"s English-Tibetan-Sanskrit Glossary|These entries are from the glossary of www.berzinarchives.com"
+    public = "true"
+
+[[titles]]
+    path = "Hopkins-Def2015"
+    id = 10
+    label = "Hopkins Definitions 2015"
+    about = "Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Hackett-Def2015"
+    id = 11
+    label = "Hackett Definitions 2015"
+    about = "Definitions by Paul Hackett|Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Hopkins-Comment"
+    id = 12
+    label = "Hopkins Comment 1992"
+    about = "Source: Jeffrey Hopkins\" Tibetan-Sanskrit-English Dictionary|Version 2.0.0, 1992|Formulator and Editor: Jeffrey Hopkins|Contributors: Joe Wilson, Craig Preston, John Powers, Nathaniel Garson, Paul Hackett, Andres Montano"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "ChandraDas_x"
+    id = 13
+    label = "Chandra Das"
+    about = "New Electronic Ediction of Sarat Chandra Das\" Tibetan-English Dictionary|version 1.023, 21st September, 2005|Padma Karpo Translation Committee, 1998-2005|If you use this dictionary, please buy it at: www.pktc.org/pktc"
+    abbreviations = "ChandraDas"
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "ThomasDoctor"
+    id = 14
+    label = "Thomas Doctor"
+    about = "Thomas Doctor\"s Tibetan-English terms|Source: Rangjung Yeshe Tibetan-English Dharma Dictionary 3.0 (2003)|online version: http://rywiki.tsadra.org"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "JimValby"
+    id = 15
+    label = "James Valby"
+    about = "James Valby\"s Tibetan-English Dictionary. © James Valby|Source: Rangjung Yeshe Tibetan-English Dharma Dictionary 3.0 (2003)|online version: http://rywiki.tsadra.org"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "IvesWaldo"
+    id = 16
+    label = "Ives Waldo"
+    about = "Ives Waldo\"s glossary compilation. © Ives Waldo|Source: Rangjung Yeshe Tibetan-English Dharma Dictionary 3.0 (2003)|online version: http://rywiki.tsadra.org"  
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "DanMartin"
+    id = 17
+    label = "Dan Martin"
+    about = "Dan Martin: “Tibetan Vocabulary.”, April 2003|This is meant to be a word-index more than a dictionary, and technical, idiosyncratic, and obsolete usages and meanings are given priority over more common ones which may readily be found in the available dictionaries.  To some degree, the content reflects my own research focus on 11th and 12th century texts.|Source: Rangjung Yeshe Tibetan-English Dharma Dictionary 3.0 (2003)|online version: http://rywiki.tsadra.org"
+    abbreviations = "DanMartin"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "RichardBarron"
+    id = 18
+    label = "Richard Barron"
+    about = "Richard Barron\"s glossary. © Copyright 2002 by Turquoise Dragon Media Services. Source: Rangjung Yeshe Tibetan-English Dharma Dictionary 3.0 (2003)|online version: http://rywiki.tsadra.org"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Hopkins-Divisions2015"
+    id = 19
+    label = "Hopkins Divisions 2015"
+    about = "Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Hopkins-Examples"
+    id = 20
+    label = "Hopkins Examples 1992"
+    about = "Source: Jeffrey Hopkins\" Tibetan-Sanskrit-English Dictionary|Version 2.0.0, 1992|Formulator and Editor: Jeffrey Hopkins|Contributors: Joe Wilson, Craig Preston, John Powers, Nathaniel Garson, Paul Hackett, Andres Montano"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "GatewayToKnowledge"
+    id = 21
+    label = "Glossary for Mipham Rinpoche's Gateway to Knowledge, Vol. 1 (Rangjung Yeshe)"
+    mergeLines = true
+    about = "Glossary for Mipham Rinpoche\"s Gateway to Knowledge, Vol. 1|Rangjung Yeshe Publications|Source: www.rangjung.com/gateway/KJ-main.htm"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Hopkins-others"
+    id = 22
+    label = "Hopkins others' English 2015"
+    about = "Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Hopkins-Synonyms"
+    id = 23
+    label = "Hopkins Synonyms 1992"
+    about = "Source: Jeffrey Hopkins\" Tibetan-Sanskrit-English Dictionary|Version 2.0.0, 1992|Formulator and Editor: Jeffrey Hopkins|Contributors: Joe Wilson, Craig Preston, John Powers, Nathaniel Garson, Paul Hackett, Andres Montano"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "MastersProgramGlossary"
+    id = 24
+    label = "FPMT Masters Program Glossary for Abhisamayaalamkara"
+    about = "This glossary was compiled from Material of the FPMT Masters Program 1998 in Pomaia (Italy)"
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "FPMT-middling-lamrim"
+    id = 25
+    label = "FPMT Glossary for Middling Lamrim (work in progress)"
+    mergeLines = true
+    about = "This glossary was compiled by the FPMT and includes key technical terms for Tsong-kha-pa\"s Middling Lamrim"
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "ComputerTerms"
+    id = 26
+    label = "Computer terms"
+    about = "Tibetan Computer Terms|Source: Standardizing Tibetan Terms of IT by the China Tibetology Research Center, 2006. This list was compiled by the Project of Standardizing Tibetan Terms of Information Technology, at the China National Center for Tibetan Studies. It was eventually published as The Dictionary of Tibetan Information Technology Terminologies. (Chinese equivalents and English-only entries were removed)"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Verbinator"
+    id = 27
+    label = "Verbinator Verb Dictionary (Tibetan)"
+    highlight = "((?:Past|Present|Future|Imperative|Meaning): )"
+    abbreviations = "Verbinator"
+    about = "\"Verbinator\" Tibetan Verb Dictionary (Verbinator 2000)|Taken from: Hill, Nathan (2010)|A Lexicon of Tibetan Verb Stems as Reported by the Grammatical Tradition. Munich: Bayerische Akademie der Wissenschaften. (Studia Tibetica)|ISBN 978-3-7696-1004-8|If you want to support the author and the publisher please consider buying this book (regular price: 58 EUR plus shipping). If you have trouble with ordering it, feel free send a mail to dictionary@christian-steinert.de and I will try to help you."
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Hopkins-TibetanTenses2015"
+    id = 28
+    containsOnlyTibetan = true
+    label = "Hopkins Tenses 2015 (Tibetan)"
+    about = "The order of the verb tenses in this dictionary is: future, present, past, imperative|Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Hopkins-TibetanSynonyms"
+    id = 29
+    containsOnlyTibetan = true
+    label = "Hopkins Synonyms 1992 (Tibetan)"
+    about = "Source: Jeffrey Hopkins\" Tibetan-Sanskrit-English Dictionary|Version 2.0.0, 1992|Formulator and Editor: Jeffrey Hopkins|Contributors: Joe Wilson, Craig Preston, John Powers, Nathaniel Garson, Paul Hackett, Andres Montano"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Hopkins-TibetanSynonyms2015"
+    id = 30
+    containsOnlyTibetan = true
+    label = "Hopkins Synonyms 2015 (Tibetan)"
+    about = "Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Sera-Textbook-Definitions"
+    id = 31
+    label = "Sera Textbook Definitions (Tibetan)"
+    about = "Sera Textbook Definitions (Tibetan)|This is a collection of various definitions from major textbook authors of Sera Monastery|The definitions are extracted from material of the Asian Classics Input Project so there will likely be typos and mistakes"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Hopkins-Divisions,Tib2015"
+    id = 32
+    containsOnlyTibetan = true
+    label = "Hopkins Divisions 2015 (Tibetan) "
+    about = "Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Hopkins-TibetanDefinitions2015"
+    id = 33
+    containsOnlyTibetan = true
+    label = "Hopkins Definitions 2015 (Tibetan) "
+    about = "Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "GesheChodrak-Tib_x"
+    id = 34
+    containsOnlyTibetan = true
+    label = "Geshe Chödrak (Tibetan)"
+    about = "Geshe Chödrak Dictionary|“Written Signals - Names and Phrases Made Clear”\nGeshe Chodrak\"s (Tibetan) Dictionary\nVersion 1.20 30th September, 2005\nPadma Karpo Translation Committee\n© TONY DUFF 2000-2004. All rights reserved.\nIf you use this dictionary, please buy it at: www.pktc.org/pktc"
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "tshig-mdzod-chen-mo-Tib"
+    id = 35
+    containsOnlyTibetan = true
+    label = "bod-rgya tshig-mdzod chen-mo (Tibetan)"
+    about = "Bod rgya tshig mdzod chen mo|1985, Mi dmangs dpe skrun khang, Beijing."
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "dung-dkar-tshig-mdzod-chen-mo-Tib"
+    id = 36
+    containsOnlyTibetan = true
+    label = "dung-dkar tshig-mdzod chen-mo (Tibetan)"
+    about = "Dung dkar tshig mdzod chen mo|Dung dkar blo bzang \"phrin las|Beijing: Krung go\"i bod rig pa dpe skrun khang 2002"
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "dag_tshig_gsar_bsgrigs-Tib"
+    id = 37
+    containsOnlyTibetan = true
+    label = "dag-yig gsar-bsgrigs (Tibetan)"
+    about = "Dag yig gsar bsgrigs|Delhi: Sherig Parkhang, Tibetan Cultural & Religious Publication Centre, 2008."
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Hopkins-Examples,Tib"
+    id = 38
+    containsOnlyTibetan = true
+    label = "Hopkins Examples 1992 (Tibetan)"
+    about = "Source: Jeffrey Hopkins\" Tibetan-Sanskrit-English Dictionary|Version 2.0.0, 1992|Formulator and Editor: Jeffrey Hopkins|Contributors: Joe Wilson, Craig Preston, John Powers, Nathaniel Garson, Paul Hackett, Andres Montano"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "LobsangMonlam-Tibetan"
+    id = 39
+    containsOnlyTibetan = true
+    label = "Lobsang Monlam (Tibetan)"
+    about = "Lobsang Monlam Dictionary|These entries were taken from the (Tibetan) portion Lobsang Monlam\"s dictionary. See http://www.monlamit.org/ for the original program."
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "FPMT-middling-lamrim-Def"
+    id = 40
+    label = "FPMT Glossary for Middling Lamrim (work in progress): Definitions"
+    about = "FPMT Glossary for Middling Lamrim|This glossary was compiled by the FPMT and includes key technical terms for Tsong-kha-pa\"s Middling Lamrim"
+    public = "false"
+    listCredits = "true"
+
+[[titles]]
+    path = "Hopkins-Skt2015"
+    id = 41
+    containsOnlySkt = false
+    label = "Hopkins Sanskrit 2015 (Tibetan-Sanskrit)"
+    about = "Source: The Uma Institute for Tibetan Studies Tibetan-Sanskrit-English Dictionary (Version: June 2015)|Jeffrey Hopkins, Editor.|Paul Hackett, Contributor and Technical Editor.| Contributors: Nathaniel Garson, William Magee, Andres Montano, John Powers, Craig Preston, Joe Wilson, Jongbok Yi|A PDF version of this dictionary is available for download at: www.uma-tibet.org"
+    abbreviations = "Hopkins"
+    public = "true"
+
+[[titles]]
+    path = "Mahavyutpatti-Skt"
+    id = 42
+    containsOnlySkt = true
+    label = "Mahavyutpatti (Tibetan-Sanskrit)"
+    about = "Mahavyutpatti |This digital edition of the Mahāvyutpatti was created by the Glossaries Team at Dharma Drum Buddhist College|See http://buddhistinformatics .ddbc.edu.tw/glossaries/ for more information."
+    public = "true"
+    listCredits = "true"
+
+[[titles]]
+    path = "Yoghacharabhumi-glossary"
+    id = 43
+    containsOnlySkt = true
+    label = "Yogacharabhumi Glossary (Tibetan-Sanskrit)"
+    about = "Tibetan-Sanskrit Table of Buddhist Terminology Based on the Yogacarabhumi|MAHONEY, Richard, ed., Tibetan-Sanskrit Buddhist Terminology based on the `Mahāvyutpatti\" and `Yogācārabhūmi\", (Oxford, North Canterbury: Indica et Buddhica, 2004)|See: http://indica-et-buddhica.org/repositorium/dictionaries/tibetan-sanskrit-terms"
+    public = "true"
+    listCredits = "true"
+
+
+


### PR DESCRIPTION
Addresses #77.

I removed the dependency from Aeson and transformed `stuff.json` into TOML format.
In doing so I added the `path` key (which was the dictionary key before) and turned the Json dictionary itself into an array named `titles`.

From:
```
{
  <path>: { /* entry */ },
  ...
}
```

to (conceptually):
```
[
  {
    "path": <path>,
    /* entry */
  },
   ...
]
```

I (manually) tested the change and it seems to work fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/willbasky/hibet/78)
<!-- Reviewable:end -->
